### PR TITLE
Implement functionality to track duration and exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ aw-watcher-terminal
 
 Currently, you can pass it the flags `--testing` for using the test server and `--verbose` for more detailed logging
 
+_Note: If you want it to autostart with aw-qt, take a look at this [this issue](https://github.com/ActivityWatch/aw-qt/issues/35)_
+
 ### Open a new terminal and start executing commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -34,5 +34,4 @@ echo "Finished installation"
 
 ## Future plans
 
-- also log execution time of commands (via precmd)
 - check for performance issues

--- a/aw_watcher_terminal/config.py
+++ b/aw_watcher_terminal/config.py
@@ -1,13 +1,14 @@
 import argparse
 from aw_core.dirs import get_data_dir
 
+watcher_name = "aw-watcher-terminal"
+
 
 def load_config():
     default_config = {
-        "pipe_path": "{}/{}".format(get_data_dir(("aw-watcher-terminal")),
-                                    "aw-watcher-terminal-fifo"),
-        "client_id": "aw-watcher-terminal-test-client",
-        "bucket_name": "aw-watcher-terminal",
+        "data_dir": get_data_dir((watcher_name)),
+        "client_id": "{}-test-client".format(watcher_name),
+        "bucket_name": watcher_name,
         "event_type": "app.terminal.activity",
         "disabled": False,
         "verbose": False,

--- a/aw_watcher_terminal/config.py
+++ b/aw_watcher_terminal/config.py
@@ -4,7 +4,7 @@ from aw_core.log import setup_logging
 from aw_core.dirs import get_data_dir
 
 
-def load_config():
+def load_config() -> None:
     args = parse_args()
 
     global watcher_name
@@ -31,7 +31,7 @@ def load_config():
                   verbose=verbose, log_stderr=True, log_file=True)
 
 
-def parse_args():
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description='Process terminal activity.')
     parser.add_argument("--testing", dest="testing", action="store_true")
     parser.add_argument("--verbose", dest="verbose", action="store_true")

--- a/aw_watcher_terminal/config.py
+++ b/aw_watcher_terminal/config.py
@@ -8,22 +8,23 @@ def load_config():
     args = parse_args()
 
     global watcher_name
-    watcher_name = "aw-watcher-terminal"
     global data_dir
-    data_dir = get_data_dir(watcher_name)
     global client
-    client = None
     global client_id
-    client_id = "{}-test-client".format(watcher_name)
     global bucket_id
-    bucket_id = None
     global event_type
-    event_type = "app.terminal.activity"
     global logger
-    logger = logging.getLogger(__name__)
     global verbose
-    verbose = args.verbose
     global testing
+
+    watcher_name = "aw-watcher-terminal"
+    data_dir = get_data_dir(watcher_name)
+    client = None
+    client_id = "{}-test-client".format(watcher_name)
+    bucket_id = None
+    event_type = "app.terminal.activity"
+    logger = logging.getLogger(__name__)
+    verbose = args.verbose
     testing = args.testing
 
     setup_logging(name=watcher_name, testing=testing,

--- a/aw_watcher_terminal/config.py
+++ b/aw_watcher_terminal/config.py
@@ -1,24 +1,33 @@
 import argparse
+import logging
+from aw_core.log import setup_logging
 from aw_core.dirs import get_data_dir
-
-watcher_name = "aw-watcher-terminal"
 
 
 def load_config():
-    default_config = {
-        "data_dir": get_data_dir((watcher_name)),
-        "client_id": "{}-test-client".format(watcher_name),
-        "bucket_name": watcher_name,
-        "event_type": "app.terminal.activity",
-        "disabled": False,
-        "verbose": False,
-        "testing": False
-    }
+    args = parse_args()
 
-    args = vars(parse_args())
-    config = {**default_config, **args}
+    global watcher_name
+    watcher_name = "aw-watcher-terminal"
+    global data_dir
+    data_dir = get_data_dir(watcher_name)
+    global client
+    client = None
+    global client_id
+    client_id = "{}-test-client".format(watcher_name)
+    global bucket_id
+    bucket_id = None
+    global event_type
+    event_type = "app.terminal.activity"
+    global logger
+    logger = logging.getLogger(__name__)
+    global verbose
+    verbose = args.verbose
+    global testing
+    testing = args.testing
 
-    return config
+    setup_logging(name=watcher_name, testing=testing,
+                  verbose=verbose, log_stderr=True, log_file=True)
 
 
 def parse_args():

--- a/aw_watcher_terminal/config.py
+++ b/aw_watcher_terminal/config.py
@@ -5,6 +5,7 @@ from aw_core.dirs import get_data_dir
 
 
 def load_config() -> None:
+    """Load the configurations"""
     args = parse_args()
 
     global data_dir
@@ -30,7 +31,7 @@ def load_config() -> None:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description='Process terminal activity.')
+    parser = argparse.ArgumentParser(description='Terminal activity watcher.')
     parser.add_argument("--testing", dest="testing", action="store_true")
     parser.add_argument("--verbose", dest="verbose", action="store_true")
     return parser.parse_args()

--- a/aw_watcher_terminal/config.py
+++ b/aw_watcher_terminal/config.py
@@ -7,7 +7,6 @@ from aw_core.dirs import get_data_dir
 def load_config() -> None:
     args = parse_args()
 
-    global watcher_name
     global data_dir
     global client
     global client_id
@@ -17,17 +16,16 @@ def load_config() -> None:
     global verbose
     global testing
 
-    watcher_name = "aw-watcher-terminal"
-    data_dir = get_data_dir(watcher_name)
+    client_id = "aw-watcher-terminal"
+    data_dir = get_data_dir(client_id)
     client = None
-    client_id = "{}-test-client".format(watcher_name)
     bucket_id = None
     event_type = "app.terminal.activity"
     logger = logging.getLogger(__name__)
     verbose = args.verbose
     testing = args.testing
 
-    setup_logging(name=watcher_name, testing=testing,
+    setup_logging(name=client_id, testing=testing,
                   verbose=verbose, log_stderr=True, log_file=True)
 
 

--- a/aw_watcher_terminal/main.py
+++ b/aw_watcher_terminal/main.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import traceback
-import sys
 import os
 from typing import Union, Callable, Any
 
@@ -47,22 +46,6 @@ def init_client():
                                       config.client.hostname)
     config.client.create_bucket(config.bucket_id, event_type=config.event_type)
     config.logger.info("Created bucket: {}".format(config.bucket_id))
-
-
-def init_fifo_listeners():
-    fifo_listeners = {
-        "preopen":  message_handler.preopen,
-        "preexec":  message_handler.preexec,
-        "precmd":   message_handler.precmd,
-        "preclose": message_handler.preclose
-    }
-    futures = []
-    for listener_name, listener in fifo_listeners.items():
-        fifo_path = "{}/fifo-{}".format(config.data_dir, listener_name)
-        setup_named_pipe(fifo_path)
-        futures.append(on_named_pipe_message(fifo_path, listener))
-
-    return futures
 
 
 def setup_named_pipe(pipe_path: str):

--- a/aw_watcher_terminal/main.py
+++ b/aw_watcher_terminal/main.py
@@ -1,20 +1,12 @@
 #!/usr/bin/env python3
-import argparse
-import logging
 import traceback
 import sys
 import os
-import shlex
 from typing import Union, Callable, Any
-import asyncio
 
 from time import sleep
-from datetime import datetime, timezone
-from aw_core.models import Event
-from aw_core.log import setup_logging
 from aw_client import ActivityWatchClient
-from config import load_config
-import shared_vars
+import config
 import message_handler
 
 
@@ -32,20 +24,12 @@ def main():
     For instance, the command 'echo "Hello \"World\""' should be escaped
     like '--command echo \"Hello \\\"World\\\"\"'
     """
-    global config
-
-    shared_vars.init()
-    shared_vars.config = load_config()
-    shared_vars.logger = logging.getLogger(__name__)
-
-    setup_logging(name=shared_vars.config['bucket_name'], testing=shared_vars.config['testing'],
-                  verbose=shared_vars.config['verbose'], log_stderr=True, log_file=True)
-
-    shared_vars.logger.info("Starting aw-watcher-terminal")
+    # Load configurations
+    config.load_config()
+    config.logger.info("Starting aw-watcher-terminal")
 
     init_client()
-    # futures = init_fifo_listeners()
-    fifo_path = "{}/aw-watcher-terminal-fifo".format(shared_vars.config["data_dir"])
+    fifo_path = "{}/aw-watcher-terminal-fifo".format(config.data_dir)
     setup_named_pipe(fifo_path)
     on_named_pipe_message(fifo_path, message_handler.handle_fifo_message)
 
@@ -54,14 +38,15 @@ def init_client():
     """Initialize the AW client and bucket"""
 
     # Create client in testing mode
-    shared_vars.client = ActivityWatchClient(shared_vars.config['client_id'],
-                                             testing=shared_vars.config['testing'])
-    shared_vars.logger.info("Initialized AW Client")
+    config.client = ActivityWatchClient(config.client_id,
+                                        testing=config.testing)
+    config.logger.info("Initialized AW Client")
 
     # Create Bucket if not already existing
-    shared_vars.bucket_id = "{}_{}".format(shared_vars.config['bucket_name'], shared_vars.client.hostname)
-    shared_vars.client.create_bucket(shared_vars.bucket_id, event_type=shared_vars.config['event_type'])
-    shared_vars.logger.info("Created bucket: {}".format(shared_vars.bucket_id))
+    config.bucket_id = "{}_{}".format(config.watcher_name,
+                                      config.client.hostname)
+    config.client.create_bucket(config.bucket_id, event_type=config.event_type)
+    config.logger.info("Created bucket: {}".format(config.bucket_id))
 
 
 def init_fifo_listeners():
@@ -73,8 +58,7 @@ def init_fifo_listeners():
     }
     futures = []
     for listener_name, listener in fifo_listeners.items():
-        fifo_path = "{}/fifo-{}".format(shared_vars.config["data_dir"],
-                                        listener_name)
+        fifo_path = "{}/fifo-{}".format(config.data_dir, listener_name)
         setup_named_pipe(fifo_path)
         futures.append(on_named_pipe_message(fifo_path, listener))
 
@@ -86,7 +70,7 @@ def setup_named_pipe(pipe_path: str):
     if os.path.exists(pipe_path):
         os.remove(pipe_path)
     if not os.path.exists(pipe_path):
-        shared_vars.logger.debug("Creating pipe {}".format(pipe_path))
+        config.logger.debug("Creating pipe {}".format(pipe_path))
         os.mkfifo(pipe_path)
 
 
@@ -94,14 +78,14 @@ def on_named_pipe_message(pipe_path: str, callback: Callable[[str], Any]):
     """Call callback everytime a new message is passed to the named pipe"""
     pipe_fd = os.open(pipe_path, os.O_RDONLY | os.O_NONBLOCK)
     with os.fdopen(pipe_fd) as pipe:
-        shared_vars.logger.info("Listening to pipe: {}".format(pipe_path))
+        config.logger.info("Listening to pipe: {}".format(pipe_path))
         while True:
             message = pipe.read()
             if message:
                 try:
                     callback(message)
                 except Exception as e:
-                    shared_vars.logger.error(e)
+                    config.logger.error(e)
                     traceback.print_exc()
 
             sleep(1)

--- a/aw_watcher_terminal/main.py
+++ b/aw_watcher_terminal/main.py
@@ -42,7 +42,7 @@ def init_client() -> None:
     config.logger.info("Initialized AW Client")
 
     # Create Bucket if not already existing
-    config.bucket_id = "{}_{}".format(config.watcher_name,
+    config.bucket_id = "{}_{}".format(config.client_id,
                                       config.client.hostname)
     config.client.create_bucket(config.bucket_id, event_type=config.event_type)
     config.logger.info("Created bucket: {}".format(config.bucket_id))

--- a/aw_watcher_terminal/main.py
+++ b/aw_watcher_terminal/main.py
@@ -47,10 +47,7 @@ def main():
     # futures = init_fifo_listeners()
     fifo_path = "{}/aw-watcher-terminal-fifo".format(shared_vars.config["data_dir"])
     setup_named_pipe(fifo_path)
-    futures = [on_named_pipe_message(fifo_path, message_handler.handle_fifo_message)]
-
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(asyncio.wait(futures))
+    on_named_pipe_message(fifo_path, message_handler.handle_fifo_message)
 
 
 def init_client():
@@ -93,7 +90,7 @@ def setup_named_pipe(pipe_path: str):
         os.mkfifo(pipe_path)
 
 
-async def on_named_pipe_message(pipe_path: str, callback: Callable[[str], Any]):
+def on_named_pipe_message(pipe_path: str, callback: Callable[[str], Any]):
     """Call callback everytime a new message is passed to the named pipe"""
     pipe_fd = os.open(pipe_path, os.O_RDONLY | os.O_NONBLOCK)
     with os.fdopen(pipe_fd) as pipe:
@@ -107,7 +104,7 @@ async def on_named_pipe_message(pipe_path: str, callback: Callable[[str], Any]):
                     shared_vars.logger.error(e)
                     traceback.print_exc()
 
-            await asyncio.sleep(1)
+            sleep(1)
 
 
 if __name__ == '__main__':

--- a/aw_watcher_terminal/main.py
+++ b/aw_watcher_terminal/main.py
@@ -48,8 +48,11 @@ def main():
 
     init_client()
     init_message_parser()
-    setup_named_pipe(config['pipe_path'])
-    on_named_pipe_message(config['pipe_path'], handle_pipe_message)
+
+    # Setup fifo and handler for preexec
+    fifo_preexec_path = "{}/{}".format(config["data_dir"], "fifo-preexec")
+    setup_named_pipe(fifo_preexec_path)
+    on_named_pipe_message(fifo_preexec_path, handle_pipe_message)
 
     logger.info("Listening for pipe messages...")
 

--- a/aw_watcher_terminal/main.py
+++ b/aw_watcher_terminal/main.py
@@ -9,7 +9,7 @@ import config
 import message_handler
 
 
-def main():
+def main() -> None:
     """Start aw-watcher-terminal"""
     """
     Usage:
@@ -33,7 +33,7 @@ def main():
     on_named_pipe_message(fifo_path, message_handler.handle_fifo_message)
 
 
-def init_client():
+def init_client() -> None:
     """Initialize the AW client and bucket"""
 
     # Create client in testing mode
@@ -48,7 +48,7 @@ def init_client():
     config.logger.info("Created bucket: {}".format(config.bucket_id))
 
 
-def setup_named_pipe(pipe_path: str):
+def setup_named_pipe(pipe_path: str) -> None:
     """Delete and create named pipe at specified path"""
     if os.path.exists(pipe_path):
         os.remove(pipe_path)
@@ -57,7 +57,8 @@ def setup_named_pipe(pipe_path: str):
         os.mkfifo(pipe_path)
 
 
-def on_named_pipe_message(pipe_path: str, callback: Callable[[str], Any]):
+def on_named_pipe_message(pipe_path: str,
+                          callback: Callable[[str], Any]) -> None:
     """Call callback everytime a new message is passed to the named pipe"""
     pipe_fd = os.open(pipe_path, os.O_RDONLY | os.O_NONBLOCK)
     with os.fdopen(pipe_fd) as pipe:

--- a/aw_watcher_terminal/main.py
+++ b/aw_watcher_terminal/main.py
@@ -50,7 +50,9 @@ def init_client() -> None:
     # Create Bucket if not already existing
     config.bucket_id = "{}_{}".format(config.client_id,
                                       config.client.hostname)
-    config.client.create_bucket(config.bucket_id, event_type=config.event_type)
+    config.client.create_bucket(config.bucket_id,
+                                event_type=config.event_type,
+                                queued=True)
     config.logger.info("Created bucket: {}".format(config.bucket_id))
 
 

--- a/aw_watcher_terminal/message_handler.py
+++ b/aw_watcher_terminal/message_handler.py
@@ -28,16 +28,26 @@
 
 import argparse
 import shlex
+from datetime import datetime, timezone
 from time import sleep
 from aw_core.models import Event
+import shared_vars
 
+
+# Parser general
+# general --event preexec
+parser_general = argparse.ArgumentParser(description='Parses the event')
+parser_general.add_argument('--event', dest='event', required=True,
+                            help='the trigger event (e.g. preexec)')
 
 # Parser preopen
+# preopen --pid 1234
 parser_preopen = argparse.ArgumentParser(description='Parses preopen messages')
 parser_preopen.add_argument('--pid', dest='pid', required=True,
                             help='the process id of the current terminal')
 
 # Parser preexec
+# preopen --pid 1234 --command ls --path /my/path --shell bash
 parser_preexec = argparse.ArgumentParser(description='Parses preexec messages')
 parser_preexec.add_argument('--pid', dest='pid', required=True,
                             help='the process id of the current terminal')
@@ -47,10 +57,9 @@ parser_preexec.add_argument('--path', dest='path',
                             help='the path of the shell')
 parser_preexec.add_argument('--shell', dest='shell',
                             help='the name of the shell used')
-parser_preexec.add_argument('--shell-version', dest='shell_version',
-                            help='the version of the shell used')
 
 # Parser precmd
+# precmd --pid 1234 --exit-code 0
 parser_precmd = argparse.ArgumentParser(description='Parses precmd messages')
 parser_precmd.add_argument('--pid', dest='pid', required=True,
                            help='the process id of the current terminal')
@@ -58,18 +67,19 @@ parser_precmd.add_argument('--exit-code', dest='exit_code',
                            help='the exit code of the last command')
 
 # Parser preclose
+# preclose --pid 1234
 parser_preclose = argparse.ArgumentParser(description=('Parses preclose '
                                           'messages'))
 parser_preclose.add_argument('--pid', dest='pid', required=True,
                              help='the process id of the current terminal')
 
 
-# Dict containing statuses of process ids
+# Dict containing data related to process ids
 # Keys are the process ids
-terminal_processes = {}
+terminal_processes_data = {}
 
 
-class TerminalProcess:
+class TerminalProcessData:
     def __init__(self, pid: str):
         self.pid = pid
 
@@ -80,73 +90,104 @@ class TerminalProcess:
             - executing
         """
         self.status = "waiting_for_prompt"
-        self.event_id = None
+        self.event = None
 
 
-def parse_fifo_message(parser: argparse.ArgumentParser) -> (argparse.Namespace, list):
-    """Parse a fifo message with the specified parser"""
-
+def parse_args(parser: argparse.ArgumentParser) -> (argparse.Namespace, list):
+    """Parse a list of arguments with the specified parser"""
     def decorator(func):
-        def decorated_function(message: str):
-            for line in message.split('\n'):
-                if not len(line):
-                    continue
+        def decorated_function(args_raw):
+            args, unknown_args = parser.parse_known_args(args_raw)
 
-                args, unknown_args = parser.parse_known_args(shlex.split(line))
-
-                return func(args, unknown_args)
+            return func(args, unknown_args)
         return decorated_function
     return decorator
 
 
-@parse_fifo_message(parser_preopen)
+def split_fifo_message_into_cli_args(func):
+    """Split a fifo message into command line arguments"""
+    def decorated_function(message: str):
+        for line in message.split('\n'):
+            if not len(line):
+                continue
+            cli_args = shlex.split(line)
+            return func(cli_args)
+    return decorated_function
+
+
+@split_fifo_message_into_cli_args
+@parse_args(parser_general)
+def handle_fifo_message(args, unknown_args):
+    shared_vars.logger.debug("Handling fifo message: {}".format(args))
+
+    possible_events = {
+        "preopen": preopen,
+        "preexec": preexec,
+        "precmd": precmd,
+        "preclose": preclose
+    }
+
+    if args.event not in possible_events:
+        shared_vars.logger.error("Unknown event: {}".format(args.event))
+    else:
+        # Call the event handler with the remaining args
+        possible_events[args.event](unknown_args)
+
+
+@parse_args(parser_preopen)
 def preopen(args, unknown_args):
     """Handle terminal creation"""
-    terminal_proccess = TerminalProcess(args.pid)
-    terminal_processes[args.pid] = TerminalProcess(args.pid)
+    shared_vars.logger.debug("preopen | pid={}".format(args.pid))
+    terminal_processes_data[args.pid] = TerminalProcessData(args.pid)
 
 
-@parse_fifo_message(parser_preexec)
+@parse_args(parser_preexec)
 def preexec(args, unknown_args):
-    process = terminal_processes[args.pid]
+    shared_vars.logger.debug("preexec | command={}".format(args.command))
+    process = terminal_processes_data[args.pid]
     process.status = "processing"
 
     # Send event
-    inserted_event = send_event(args)
-    print(inserted_event)
+    process.event = insert_event(vars(args))
 
-    event_id = inserted_event.id
-    process.event_id = event_id
     process.status = "executing"
 
 
-@parse_fifo_message(parser_precmd)
+@parse_args(parser_precmd)
 def precmd(args, unknown_args):
-    process = terminal_processes[args.pid]
+    shared_vars.logger.debug("precmd | exit_code={}".format(args.exit_code))
+    process = terminal_processes_data[args.pid]
 
     if process.status != "executing":
-        print("Not implemented yet")
+        shared_vars.logger.error("Not implemented yet")
 
-    event = get_event(process.event_id)
-    event.duration = [...]
-    event.exit_code = args.exit_code
-    send_event(event)
+    # TODO: Alter execution_time / duration of the event
+    print(process.event.data)
+    print(type(process.event.data))
+    event_data = process.event.data
+    print(type(event_data))
+    print(event_data)
+    event_data["exit_code"] = args.exit_code
+    insert_event(event_data)
 
 
-@parse_fifo_message(parser_preclose)
+@parse_args(parser_preclose)
 def preclose(args, unknown_args):
-    terminal_processes.pop(args.pid)
+    shared_vars.logger.debug("preclose | pid={}".format(args.pid))
+    terminal_processes_data.pop(args.pid)
 
 
-class AttrDict(dict):
-    def __init__(self, *args, **kwargs):
-        super(AttrDict, self).__init__(*args, **kwargs)
-        self.__dict__ = self
+def insert_event(event_data: dict) -> Event:
+    """Send event to the aw-server"""
+    shared_vars.logger.debug("Sending event")
+    shared_vars.logger.debug(event_data)
+    now = datetime.now(timezone.utc)
+    event = Event(timestamp=now, data=event_data)
+    inserted_event = shared_vars.client.insert_event(shared_vars.bucket_id,
+                                                     event)
 
+    # The event returned from insert_event has been assigned an id by aw-server
+    assert inserted_event.id is not None
+    shared_vars.logger.info("Successfully sent event")
 
-def send_event(event):
-    return Event("1")
-
-
-def get_event(event_id):
-    return Event()
+    return inserted_event

--- a/aw_watcher_terminal/message_handler.py
+++ b/aw_watcher_terminal/message_handler.py
@@ -93,9 +93,12 @@ def parse_args(parser: argparse.ArgumentParser) -> EventHandlerDecorator:
     """Parse a list of arguments with the specified parser"""
     def decorator(func: EventHandler) -> Callable[[list], Any]:
         def decorated_function(args_raw: list) -> Any:
-            args, unknown_args = parser.parse_known_args(args_raw)
-
-            return func(args, unknown_args)
+            try:
+                args, unknown_args = parser.parse_known_args(args_raw)
+                return func(args, unknown_args)
+            except (argparse.ArgumentError, argparse.ArgumentTypeError,
+                    SystemExit) as e:
+                config.logger.error("Error while parsing args")
         return decorated_function
     return decorator
 

--- a/aw_watcher_terminal/message_handler.py
+++ b/aw_watcher_terminal/message_handler.py
@@ -1,24 +1,3 @@
-"""
-    Handle fifo message:
-        preopen:
-            store pid
-
-        preexec:
-            send event
-            save event to pid
-
-        precmd:
-            update event:
-                set duration
-                set exit code
-            send event
-            rmove old event from pid
-
-        preclose:
-            remove pid
-
-"""
-
 import argparse
 import shlex
 from time import sleep
@@ -26,19 +5,18 @@ from aw_core.models import Event
 import config
 
 
-# Parser general
+# Event parsers
+#
 # general --event preexec
 parser_general = argparse.ArgumentParser(description='Parses the event')
 parser_general.add_argument('--event', dest='event', required=True,
                             help='the trigger event (e.g. preexec)')
 
-# Parser preopen
 # preopen --pid 1234
 parser_preopen = argparse.ArgumentParser(description='Parses preopen messages')
 parser_preopen.add_argument('--pid', dest='pid', required=True,
                             help='the process id of the current terminal')
 
-# Parser preexec
 # preopen --pid 1234 --command ls --path /my/path --shell bash
 parser_preexec = argparse.ArgumentParser(description='Parses preexec messages')
 parser_preexec.add_argument('--pid', dest='pid', required=True,
@@ -50,7 +28,6 @@ parser_preexec.add_argument('--path', dest='path',
 parser_preexec.add_argument('--shell', dest='shell',
                             help='the name of the shell used')
 
-# Parser precmd
 # precmd --pid 1234 --exit-code 0
 parser_precmd = argparse.ArgumentParser(description='Parses precmd messages')
 parser_precmd.add_argument('--pid', dest='pid', required=True,
@@ -58,7 +35,6 @@ parser_precmd.add_argument('--pid', dest='pid', required=True,
 parser_precmd.add_argument('--exit-code', dest='exit_code',
                            help='the exit code of the last command')
 
-# Parser preclose
 # preclose --pid 1234
 parser_preclose = argparse.ArgumentParser(description=('Parses preclose '
                                           'messages'))
@@ -136,6 +112,11 @@ def for_line_in_str(func):
 @split_str_into_cli_args
 @parse_args(parser_general)
 def handle_fifo_message(args, unknown_args):
+    """Call the specified event handler with the remaining args"""
+
+    # TODO: Check what happens if preexec and precmd order is swapped
+    # (e.g. because aw-watcher-bash-preexec is too slow)
+
     possible_events = {
         "preopen": preopen,
         "preexec": preexec,
@@ -146,7 +127,6 @@ def handle_fifo_message(args, unknown_args):
     if args.event not in possible_events:
         config.logger.error("Unknown event: {}".format(args.event))
     else:
-        # Call the event handler with the remaining args
         possible_events[args.event](unknown_args)
 
 
@@ -155,6 +135,7 @@ def handle_fifo_message(args, unknown_args):
 @store_pid_if_not_existing
 def preopen(args, unknown_args):
     """Handle terminal creation"""
+    # work done by decorators
     pass
 
 
@@ -163,8 +144,6 @@ def preopen(args, unknown_args):
 @store_pid_if_not_existing
 def preexec(args, unknown_args):
     process = terminal_processes_data[args.pid]
-
-    # Send event
     process.event = insert_event(vars(args))
 
 
@@ -174,8 +153,6 @@ def preexec(args, unknown_args):
 def precmd(args, unknown_args):
     process = terminal_processes_data[args.pid]
 
-    # TODO: Check what happens if preexec and precmd order is swapped
-    # (e.g. because aw-watcher-bash-preexec is too slow)
     if process.event is None:
         return
 
@@ -183,6 +160,8 @@ def precmd(args, unknown_args):
     event_data = process.event.data
     event_data["exit_code"] = args.exit_code
     insert_event(event_data, id=process.event.id)
+
+    process.event = None
 
 
 @parse_args(parser_preclose)

--- a/aw_watcher_terminal/message_handler.py
+++ b/aw_watcher_terminal/message_handler.py
@@ -79,12 +79,11 @@ def log_args(func_name: str, keys: list) -> EventHandlerDecorator:
     def decorator(func: EventHandler) -> EventHandler:
         def decorated_function(args: argparse.Namespace,
                                unknown_args: list) -> Any:
-            log_msg = func_name
+            config.logger.debug(func_name)
             for key in keys:
                 if key in vars(args):
-                    log_msg += "\n| {}={}".format(key, vars(args)[key])
+                    config.logger.debug("| {}={}".format(key, vars(args)[key]))
 
-            config.logger.debug(log_msg)
             return func(args, unknown_args)
         return decorated_function
     return decorator
@@ -103,7 +102,7 @@ def parse_args(parser: argparse.ArgumentParser) -> EventHandlerDecorator:
 
 def split_str_into_cli_args(func: Callable[
                                     [list], Any]) -> Callable[[str], Any]:
-    """Split a fifo message into command line arguments"""
+    """Split a string containing cli args into a list of cli args"""
     def decorator(message: str) -> Any:
         cli_args = shlex.split(message)
         return func(cli_args)

--- a/aw_watcher_terminal/message_handler.py
+++ b/aw_watcher_terminal/message_handler.py
@@ -1,0 +1,152 @@
+"""
+    Handle fifo message:
+        preopen:
+            store pid
+
+        preexec:
+            set pid status processing
+            parse args
+            send event
+            save eventid to pid
+            set pid status executing
+
+        precmd:
+            if pid status == processing:
+                sleep (x) and repeat
+            if pid_status == executing:
+                pid_status = waiting_for_prompt
+                remove eventid from pid
+                get event by pid and eventid
+                set duration
+                set exit code
+                send event
+
+        preclose:
+            remove pid
+
+"""
+
+import argparse
+import shlex
+from time import sleep
+from aw_core.models import Event
+
+
+# Parser preopen
+parser_preopen = argparse.ArgumentParser(description='Parses preopen messages')
+parser_preopen.add_argument('--pid', dest='pid', required=True,
+                            help='the process id of the current terminal')
+
+# Parser preexec
+parser_preexec = argparse.ArgumentParser(description='Parses preexec messages')
+parser_preexec.add_argument('--pid', dest='pid', required=True,
+                            help='the process id of the current terminal')
+parser_preexec.add_argument('--command', dest='command',
+                            help='the command entered by the user')
+parser_preexec.add_argument('--path', dest='path',
+                            help='the path of the shell')
+parser_preexec.add_argument('--shell', dest='shell',
+                            help='the name of the shell used')
+parser_preexec.add_argument('--shell-version', dest='shell_version',
+                            help='the version of the shell used')
+
+# Parser precmd
+parser_precmd = argparse.ArgumentParser(description='Parses precmd messages')
+parser_precmd.add_argument('--pid', dest='pid', required=True,
+                           help='the process id of the current terminal')
+parser_precmd.add_argument('--exit-code', dest='exit_code',
+                           help='the exit code of the last command')
+
+# Parser preclose
+parser_preclose = argparse.ArgumentParser(description=('Parses preclose '
+                                          'messages'))
+parser_preclose.add_argument('--pid', dest='pid', required=True,
+                             help='the process id of the current terminal')
+
+
+# Dict containing statuses of process ids
+# Keys are the process ids
+terminal_processes = {}
+
+
+class TerminalProcess:
+    def __init__(self, pid: str):
+        self.pid = pid
+
+        """
+            Status can be one of following:
+            - waiting_for_prompt
+            - processing (meaning, that this program is processing the pid)
+            - executing
+        """
+        self.status = "waiting_for_prompt"
+        self.event_id = None
+
+
+def parse_fifo_message(parser: argparse.ArgumentParser) -> (argparse.Namespace, list):
+    """Parse a fifo message with the specified parser"""
+
+    def decorator(func):
+        def decorated_function(message: str):
+            for line in message.split('\n'):
+                if not len(line):
+                    continue
+
+                args, unknown_args = parser.parse_known_args(shlex.split(line))
+
+                return func(args, unknown_args)
+        return decorated_function
+    return decorator
+
+
+@parse_fifo_message(parser_preopen)
+def preopen(args, unknown_args):
+    """Handle terminal creation"""
+    terminal_proccess = TerminalProcess(args.pid)
+    terminal_processes[args.pid] = TerminalProcess(args.pid)
+
+
+@parse_fifo_message(parser_preexec)
+def preexec(args, unknown_args):
+    process = terminal_processes[args.pid]
+    process.status = "processing"
+
+    # Send event
+    inserted_event = send_event(args)
+    print(inserted_event)
+
+    event_id = inserted_event.id
+    process.event_id = event_id
+    process.status = "executing"
+
+
+@parse_fifo_message(parser_precmd)
+def precmd(args, unknown_args):
+    process = terminal_processes[args.pid]
+
+    if process.status != "executing":
+        print("Not implemented yet")
+
+    event = get_event(process.event_id)
+    event.duration = [...]
+    event.exit_code = args.exit_code
+    send_event(event)
+
+
+@parse_fifo_message(parser_preclose)
+def preclose(args, unknown_args):
+    terminal_processes.pop(args.pid)
+
+
+class AttrDict(dict):
+    def __init__(self, *args, **kwargs):
+        super(AttrDict, self).__init__(*args, **kwargs)
+        self.__dict__ = self
+
+
+def send_event(event):
+    return Event("1")
+
+
+def get_event(event_id):
+    return Event()

--- a/aw_watcher_terminal/shared_vars.py
+++ b/aw_watcher_terminal/shared_vars.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+
+
+def init():
+    global config
+    global client
+    global bucket_id
+    global logger

--- a/aw_watcher_terminal/shared_vars.py
+++ b/aw_watcher_terminal/shared_vars.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python3
-
-
-def init():
-    global config
-    global client
-    global bucket_id
-    global logger

--- a/aw_watcher_terminal/test/test.py
+++ b/aw_watcher_terminal/test/test.py
@@ -3,6 +3,7 @@ import argparse
 import logging
 from aw_watcher_terminal.main import init_message_parser, parse_pipe_message
 
+"""Outdated
 
 class TestPipeMessageParser(unittest.TestCase):
     # TODO: Update depending on specification
@@ -36,6 +37,7 @@ class TestPipeMessageParser(unittest.TestCase):
         self.assertEqual('/home/', parsed.path)
         self.assertEqual('bash', parsed.shell)
         self.assertEqual('1.2.3', parsed.shell_version)
+"""
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I've added following events (which will be passed as parameter to the named pipe):
- preopen (when the terminal gets opened / .bashrc gets loaded)
- preexec (when a command gets executed)
- precmd  (after a command / when the terminal waits for command input)
- preclose (when the terminal gets closed)

TODO:
- [x] Add timestamps so the order is definitely correct (contrary to precmd being called before preexec)
- [x] Tidy code
- [x] Consider merging config.py and shared_vars.py
- [x] Better documentation (in readme and code)
- [ ] Update tests ([postponed](https://github.com/Otto-AA/aw-watcher-terminal/issues/6))
